### PR TITLE
feat: init integration api with commands, model and plugin interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee</groupId>
+        <artifactId>gravitee-parent</artifactId>
+        <version>22.0.14</version>
+    </parent>
+
+    <groupId>io.gravitee.integration</groupId>
+    <artifactId>gravitee-integration-api</artifactId>
+    <version>1.0.0-init-SNAPSHOT</version>
+    <name>Gravitee.io Integration - API</name>
+
+    <properties>
+        <gravitee-bom.version>7.0.13</gravitee-bom.version>
+        <gravitee-common.version>4.0.0</gravitee-common.version>
+        <gravitee-exchange.version>1.0.0-alpha.7</gravitee-exchange.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.gravitee.exchange</groupId>
+            <artifactId>gravitee-exchange-api</artifactId>
+            <version>${gravitee-exchange.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.reactivex.rxjava3</groupId>
+            <artifactId>rxjava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/main/java/io/gravitee/integration/api/command/IntegrationCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/IntegrationCommand.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.gravitee.exchange.api.command.Command;
+import io.gravitee.exchange.api.command.Payload;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class IntegrationCommand<P extends Payload> extends Command<P> {
+
+    protected IntegrationCommand(final IntegrationCommandType type) {
+        super(type.name());
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/IntegrationCommandType.java
+++ b/src/main/java/io/gravitee/integration/api/command/IntegrationCommandType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum IntegrationCommandType {
+    FETCH,
+    HELLO,
+    LIST,
+    STOP,
+    SUBSCRIBE,
+}

--- a/src/main/java/io/gravitee/integration/api/command/IntegrationReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/IntegrationReply.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.exchange.api.command.Reply;
+import io.gravitee.integration.api.command.fetch.FetchReply;
+import io.gravitee.integration.api.command.list.ListReply;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class IntegrationReply<P extends Payload> extends Reply<P> {
+
+    protected IntegrationReply(final IntegrationCommandType type) {
+        super(type.name());
+    }
+
+    protected IntegrationReply(IntegrationCommandType type, String commandId, CommandStatus commandStatus) {
+        super(type.name(), commandId, commandStatus);
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.fetch;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class FetchCommand extends IntegrationCommand<FetchCommandPayload> {
+
+    public FetchCommand() {
+        super(IntegrationCommandType.FETCH);
+    }
+
+    public FetchCommand(final FetchCommandPayload fetchCommandPayload) {
+        this();
+        this.payload = fetchCommandPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommandPayload.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.fetch;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Asset;
+import java.util.List;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record FetchCommandPayload(List<Asset> assets) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchReply.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.fetch;
+
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.IntegrationReply;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class FetchReply extends IntegrationReply<FetchReplyPayload> {
+
+    public FetchReply() {
+        super(IntegrationCommandType.FETCH);
+    }
+
+    public FetchReply(String commandId, String errorDetails) {
+        super(IntegrationCommandType.FETCH, commandId, CommandStatus.ERROR);
+        this.errorDetails = errorDetails;
+    }
+
+    public FetchReply(String commandId, FetchReplyPayload fetchReplyPayload) {
+        super(IntegrationCommandType.FETCH, commandId, CommandStatus.SUCCEEDED);
+        this.payload = fetchReplyPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchReplyPayload.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.fetch;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Asset;
+import java.util.List;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record FetchReplyPayload(List<Asset> assets) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/hello/HelloCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/hello/HelloCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.hello;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HelloCommand extends IntegrationCommand<HelloCommandPayload> {
+
+    public HelloCommand() {
+        super(IntegrationCommandType.HELLO);
+    }
+
+    public HelloCommand(final String originalCommandId, final HelloCommandPayload helloCommandPayload) {
+        this();
+        this.id = originalCommandId;
+        this.payload = helloCommandPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.hello;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Getter
+@Setter
+public class HelloCommandPayload extends io.gravitee.exchange.api.command.hello.HelloCommandPayload {
+
+    private String provider;
+    private String environmentId;
+}

--- a/src/main/java/io/gravitee/integration/api/command/list/ListCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListCommand.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.list;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ListCommand extends IntegrationCommand<ListCommandPayload> {
+
+    public ListCommand() {
+        super(IntegrationCommandType.LIST);
+        this.payload = new ListCommandPayload();
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/list/ListCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListCommandPayload.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.list;
+
+import io.gravitee.exchange.api.command.Payload;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record ListCommandPayload() implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/list/ListReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListReply.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.list;
+
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.IntegrationReply;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ListReply extends IntegrationReply<ListReplyPayload> {
+
+    public ListReply() {
+        super(IntegrationCommandType.LIST);
+    }
+
+    public ListReply(String commandId, String errorDetails) {
+        super(IntegrationCommandType.LIST, commandId, CommandStatus.ERROR);
+        this.errorDetails = errorDetails;
+    }
+
+    public ListReply(String commandId, ListReplyPayload listReplyPayload) {
+        super(IntegrationCommandType.LIST, commandId, CommandStatus.SUCCEEDED);
+        this.payload = listReplyPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/list/ListReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListReplyPayload.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.list;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Asset;
+import java.util.List;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record ListReplyPayload(List<Asset> assets) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommand.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.subscribe;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SubscribeCommand extends IntegrationCommand<SubscribeCommandPayload> {
+
+    public SubscribeCommand() {
+        super(IntegrationCommandType.SUBSCRIBE);
+    }
+
+    public SubscribeCommand(final SubscribeCommandPayload subscribeCommandPayload) {
+        this();
+        this.payload = subscribeCommandPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommandPayload.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.subscribe;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Asset;
+import io.gravitee.integration.api.model.Subscription;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record SubscribeCommandPayload(Asset asset, Subscription subscription) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReply.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.subscribe;
+
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.IntegrationReply;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SubscribeReply extends IntegrationReply<SubscribeReplyPayload> {
+
+    public SubscribeReply() {
+        super(IntegrationCommandType.SUBSCRIBE);
+    }
+
+    public SubscribeReply(String commandId, String errorDetails) {
+        super(IntegrationCommandType.SUBSCRIBE, commandId, CommandStatus.ERROR);
+        this.errorDetails = errorDetails;
+    }
+
+    public SubscribeReply(String commandId, SubscribeReplyPayload subscribeReplyPayload) {
+        super(IntegrationCommandType.SUBSCRIBE, commandId, CommandStatus.SUCCEEDED);
+        this.payload = subscribeReplyPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReplyPayload.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.command.subscribe;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Subscription;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record SubscribeReplyPayload(Subscription subscription) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/model/Asset.java
+++ b/src/main/java/io/gravitee/integration/api/model/Asset.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({ "id", "name", "version", "description", "host", "path", "type", "pages", "plans" })
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public final class Asset implements Serializable {
+
+    private String id;
+    private String name;
+    private String version;
+    private String description;
+    private String host;
+    private String path;
+    private AssetType type;
+    private List<Page> pages;
+    private List<Plan> plans;
+}

--- a/src/main/java/io/gravitee/integration/api/model/AssetType.java
+++ b/src/main/java/io/gravitee/integration/api/model/AssetType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum AssetType {
+    OPENAPI,
+    ASYNCAPI,
+}

--- a/src/main/java/io/gravitee/integration/api/model/Integration.java
+++ b/src/main/java/io/gravitee/integration/api/model/Integration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Integration {
+
+    String id;
+    String name;
+    String remoteId;
+    DeploymentType deploymentType;
+    String provider;
+    String configuration;
+    String environmentId;
+
+    public enum Feature {
+        SUBSCRIBE,
+    }
+
+    public enum DeploymentType {
+        REMOTE,
+        EMBEDDED,
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/model/Page.java
+++ b/src/main/java/io/gravitee/integration/api/model/Page.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record Page(PageType pageType, String content) {}

--- a/src/main/java/io/gravitee/integration/api/model/PageType.java
+++ b/src/main/java/io/gravitee/integration/api/model/PageType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum PageType {
+    ASCIIDOC,
+    ASYNCAPI,
+    MARKDOWN,
+    MARKDOWN_TEMPLATE,
+    SWAGGER,
+}

--- a/src/main/java/io/gravitee/integration/api/model/Plan.java
+++ b/src/main/java/io/gravitee/integration/api/model/Plan.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record Plan(String id, PlanSecurityType planSecurityType) {}

--- a/src/main/java/io/gravitee/integration/api/model/PlanSecurityType.java
+++ b/src/main/java/io/gravitee/integration/api/model/PlanSecurityType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum PlanSecurityType {
+    API_KEY,
+    OAUTH,
+    JWT,
+}

--- a/src/main/java/io/gravitee/integration/api/model/Subscription.java
+++ b/src/main/java/io/gravitee/integration/api/model/Subscription.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+import java.util.Map;
+import lombok.Builder;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Builder
+public record Subscription(
+    String graviteeApiId,
+    String graviteeApplicationId,
+    String graviteeUserId,
+    String graviteeSubscriptionId,
+    String graviteeEnvironmentId,
+    String graviteeOrganizationId,
+    String reason,
+    SubscriptionType type,
+
+    String apiKey,
+    Map<String, String> metadata
+) {}

--- a/src/main/java/io/gravitee/integration/api/model/SubscriptionType.java
+++ b/src/main/java/io/gravitee/integration/api/model/SubscriptionType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.model;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum SubscriptionType {
+    API_KEY,
+    OAUTH,
+    JWT,
+}

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.plugin;
+
+import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.integration.api.model.Asset;
+import io.gravitee.integration.api.model.Subscription;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface IntegrationProvider extends LifecycleComponent<IntegrationProvider> {
+    Flowable<Asset> listAssets();
+
+    Flowable<Asset> fetchAssets(List<Asset> assets);
+
+    Single<Subscription> subscribe(Asset asset, Subscription subscription);
+}

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProviderFactory.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProviderFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.plugin;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface IntegrationProviderFactory<I extends IntegrationProvider> {
+    I createIntegrationProvider(String id, String configuration);
+}

--- a/src/main/java/io/gravitee/integration/api/plugin/configuration/AbstractIntegrationProviderConfiguration.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/configuration/AbstractIntegrationProviderConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.plugin.configuration;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public abstract class AbstractIntegrationProviderConfiguration implements IntegrationProviderConfiguration {
+
+    private String id;
+}

--- a/src/main/java/io/gravitee/integration/api/plugin/configuration/IntegrationProviderConfiguration.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/configuration/IntegrationProviderConfiguration.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.gravitee.integration.api.plugin.configuration;
+
+/**
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface IntegrationProviderConfiguration {
+    String getId();
+}

--- a/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
+++ b/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.websocket.command;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.fetch.FetchCommand;
+import io.gravitee.integration.api.command.fetch.FetchReply;
+import io.gravitee.integration.api.command.hello.HelloCommand;
+import io.gravitee.integration.api.command.list.ListCommand;
+import io.gravitee.integration.api.command.list.ListReply;
+import io.gravitee.integration.api.command.subscribe.SubscribeCommand;
+import io.gravitee.integration.api.command.subscribe.SubscribeReply;
+import java.util.Map;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class IntegrationExchangeSerDe extends DefaultExchangeSerDe {
+
+    public IntegrationExchangeSerDe(final ObjectMapper objectMapper) {
+        super(
+            objectMapper,
+            Map.of(
+                IntegrationCommandType.HELLO.name(),
+                HelloCommand.class,
+                IntegrationCommandType.FETCH.name(),
+                FetchCommand.class,
+                IntegrationCommandType.LIST.name(),
+                ListCommand.class,
+                IntegrationCommandType.SUBSCRIBE.name(),
+                SubscribeCommand.class
+            ),
+            Map.of(
+                IntegrationCommandType.FETCH.name(),
+                FetchReply.class,
+                IntegrationCommandType.LIST.name(),
+                ListReply.class,
+                IntegrationCommandType.SUBSCRIBE.name(),
+                SubscribeReply.class
+            )
+        );
+    }
+}


### PR DESCRIPTION
**Description**

Reopening https://github.com/gravitee-io/gravitee-integration-api/pull/2

I've changed the renovate configuration and CI config on master and rebased the `alpha` branches. Unfortunately, GitHub lost track of the previous branch...

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-init-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-init-SNAPSHOT/gravitee-integration-api-1.0.0-init-SNAPSHOT.zip)
  <!-- Version placeholder end -->
