### PR TITLE
feat: remove environmentId in HelloPayload

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
@@ -33,5 +33,4 @@ import lombok.experimental.SuperBuilder;
 public class HelloCommandPayload extends io.gravitee.exchange.api.command.hello.HelloCommandPayload {
 
     private String provider;
-    private String environmentId;
 }


### PR DESCRIPTION
**Description**

Remove `environmentId` from HelloPayload

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-provide-integration-id-in-hello-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-provide-integration-id-in-hello-SNAPSHOT/gravitee-integration-api-1.0.0-provide-integration-id-in-hello-SNAPSHOT.zip)
  <!-- Version placeholder end -->
