### PR TITLE
fix: define lombok annotation to generate builder and equals methods

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/IntegrationCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/IntegrationCommand.java
@@ -18,12 +18,14 @@ package io.gravitee.integration.api.command;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Payload;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@EqualsAndHashCode(callSuper = true)
 public abstract class IntegrationCommand<P extends Payload> extends Command<P> {
 
     protected IntegrationCommand(final IntegrationCommandType type) {

--- a/src/main/java/io/gravitee/integration/api/command/IntegrationReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/IntegrationReply.java
@@ -17,13 +17,10 @@ package io.gravitee.integration.api.command;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.Payload;
 import io.gravitee.exchange.api.command.Reply;
-import io.gravitee.integration.api.command.fetch.FetchReply;
-import io.gravitee.integration.api.command.list.ListReply;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -31,6 +28,7 @@ import io.gravitee.integration.api.command.list.ListReply;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@EqualsAndHashCode(callSuper = true)
 public abstract class IntegrationReply<P extends Payload> extends Reply<P> {
 
     protected IntegrationReply(final IntegrationCommandType type) {

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommand.java
@@ -18,12 +18,13 @@ package io.gravitee.integration.api.command.fetch;
 
 import io.gravitee.integration.api.command.IntegrationCommand;
 import io.gravitee.integration.api.command.IntegrationCommandType;
-import lombok.experimental.SuperBuilder;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+@EqualsAndHashCode(callSuper = true)
 public class FetchCommand extends IntegrationCommand<FetchCommandPayload> {
 
     public FetchCommand() {

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchCommandPayload.java
@@ -19,9 +19,12 @@ package io.gravitee.integration.api.command.fetch;
 import io.gravitee.exchange.api.command.Payload;
 import io.gravitee.integration.api.model.Asset;
 import java.util.List;
+import lombok.Builder;
+import lombok.Singular;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record FetchCommandPayload(List<Asset> assets) implements Payload {}
+@Builder
+public record FetchCommandPayload(@Singular List<Asset> assets) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchReply.java
@@ -19,15 +19,15 @@ package io.gravitee.integration.api.command.fetch;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.integration.api.command.IntegrationCommandType;
 import io.gravitee.integration.api.command.IntegrationReply;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Getter
-@Setter
+@Builder
+@EqualsAndHashCode(callSuper = true)
 public class FetchReply extends IntegrationReply<FetchReplyPayload> {
 
     public FetchReply() {

--- a/src/main/java/io/gravitee/integration/api/command/fetch/FetchReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/fetch/FetchReplyPayload.java
@@ -19,9 +19,12 @@ package io.gravitee.integration.api.command.fetch;
 import io.gravitee.exchange.api.command.Payload;
 import io.gravitee.integration.api.model.Asset;
 import java.util.List;
+import lombok.Builder;
+import lombok.Singular;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record FetchReplyPayload(List<Asset> assets) implements Payload {}
+@Builder
+public record FetchReplyPayload(@Singular List<Asset> assets) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/list/ListCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListCommand.java
@@ -17,11 +17,13 @@ package io.gravitee.integration.api.command.list;
 
 import io.gravitee.integration.api.command.IntegrationCommand;
 import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+@EqualsAndHashCode(callSuper = true)
 public class ListCommand extends IntegrationCommand<ListCommandPayload> {
 
     public ListCommand() {

--- a/src/main/java/io/gravitee/integration/api/command/list/ListReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/list/ListReply.java
@@ -18,11 +18,14 @@ package io.gravitee.integration.api.command.list;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.integration.api.command.IntegrationCommandType;
 import io.gravitee.integration.api.command.IntegrationReply;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+
+@EqualsAndHashCode(callSuper = true)
 public class ListReply extends IntegrationReply<ListReplyPayload> {
 
     public ListReply() {

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommand.java
@@ -18,11 +18,13 @@ package io.gravitee.integration.api.command.subscribe;
 
 import io.gravitee.integration.api.command.IntegrationCommand;
 import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+@EqualsAndHashCode(callSuper = true)
 public class SubscribeCommand extends IntegrationCommand<SubscribeCommandPayload> {
 
     public SubscribeCommand() {

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeReply.java
@@ -18,11 +18,13 @@ package io.gravitee.integration.api.command.subscribe;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.integration.api.command.IntegrationCommandType;
 import io.gravitee.integration.api.command.IntegrationReply;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
+@EqualsAndHashCode(callSuper = true)
 public class SubscribeReply extends IntegrationReply<SubscribeReplyPayload> {
 
     public SubscribeReply() {

--- a/src/main/java/io/gravitee/integration/api/model/Plan.java
+++ b/src/main/java/io/gravitee/integration/api/model/Plan.java
@@ -16,8 +16,11 @@
 
 package io.gravitee.integration.api.model;
 
+import lombok.Builder;
+
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record Plan(String id, PlanSecurityType planSecurityType) {}
+@Builder
+public record Plan(String id, String name, PlanSecurityType planSecurityType) {}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4192

**Description**

Instead of providing a serialized configuration, we provide the Spring
environment with a prefix that will be used to fetch configuration
attributes.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim4192-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-apim4192-SNAPSHOT/gravitee-integration-api-1.0.0-apim4192-SNAPSHOT.zip)
  <!-- Version placeholder end -->
