### PR TITLE
feat: rename element to follow naming used in Federation team

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverCommand.java
@@ -13,18 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.gravitee.integration.api.command.discover;
 
-package io.gravitee.integration.api.command.fetch;
-
-import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.Asset;
-import java.util.List;
-import lombok.Builder;
-import lombok.Singular;
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.EqualsAndHashCode;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
-public record FetchReplyPayload(@Singular List<Asset> assets) implements Payload {}
+@EqualsAndHashCode(callSuper = true)
+public class DiscoverCommand extends IntegrationCommand<DiscoverCommandPayload> {
+
+    public DiscoverCommand() {
+        super(IntegrationCommandType.LIST);
+        this.payload = new DiscoverCommandPayload();
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverCommandPayload.java
@@ -13,26 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.gravitee.integration.api.command.discover;
 
-package io.gravitee.integration.api.command.fetch;
-
-import io.gravitee.integration.api.command.IntegrationCommand;
-import io.gravitee.integration.api.command.IntegrationCommandType;
-import lombok.EqualsAndHashCode;
+import io.gravitee.exchange.api.command.Payload;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-@EqualsAndHashCode(callSuper = true)
-public class FetchCommand extends IntegrationCommand<FetchCommandPayload> {
-
-    public FetchCommand() {
-        super(IntegrationCommandType.FETCH);
-    }
-
-    public FetchCommand(final FetchCommandPayload fetchCommandPayload) {
-        this();
-        this.payload = fetchCommandPayload;
-    }
-}
+public record DiscoverCommandPayload() implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReply.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command.list;
+package io.gravitee.integration.api.command.discover;
 
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.integration.api.command.IntegrationCommandType;
@@ -26,19 +26,19 @@ import lombok.EqualsAndHashCode;
  */
 
 @EqualsAndHashCode(callSuper = true)
-public class ListReply extends IntegrationReply<ListReplyPayload> {
+public class DiscoverReply extends IntegrationReply<DiscoverReplyPayload> {
 
-    public ListReply() {
+    public DiscoverReply() {
         super(IntegrationCommandType.LIST);
     }
 
-    public ListReply(String commandId, String errorDetails) {
+    public DiscoverReply(String commandId, String errorDetails) {
         super(IntegrationCommandType.LIST, commandId, CommandStatus.ERROR);
         this.errorDetails = errorDetails;
     }
 
-    public ListReply(String commandId, ListReplyPayload listReplyPayload) {
+    public DiscoverReply(String commandId, DiscoverReplyPayload discoverReplyPayload) {
         super(IntegrationCommandType.LIST, commandId, CommandStatus.SUCCEEDED);
-        this.payload = listReplyPayload;
+        this.payload = discoverReplyPayload;
     }
 }

--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReplyPayload.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command.list;
+package io.gravitee.integration.api.command.discover;
 
 import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.Asset;
+import io.gravitee.integration.api.model.Api;
 import java.util.List;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record ListReplyPayload(List<Asset> assets) implements Payload {}
+public record DiscoverReplyPayload(List<Api> apis) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/ingest/IngestCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/ingest/IngestCommand.java
@@ -13,12 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command.list;
 
-import io.gravitee.exchange.api.command.Payload;
+package io.gravitee.integration.api.command.ingest;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record ListCommandPayload() implements Payload {}
+@EqualsAndHashCode(callSuper = true)
+public class IngestCommand extends IntegrationCommand<IngestCommandPayload> {
+
+    public IngestCommand() {
+        super(IntegrationCommandType.FETCH);
+    }
+
+    public IngestCommand(final IngestCommandPayload ingestCommandPayload) {
+        this();
+        this.payload = ingestCommandPayload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/ingest/IngestCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/ingest/IngestCommandPayload.java
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 
-package io.gravitee.integration.api.model;
+package io.gravitee.integration.api.command.ingest;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Api;
+import java.util.List;
+import lombok.Builder;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-public enum AssetType {
-    OPENAPI,
-    ASYNCAPI,
-}
+@Builder
+public record IngestCommandPayload(List<Api> apis) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/ingest/IngestReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/ingest/IngestReply.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.gravitee.integration.api.command.fetch;
+package io.gravitee.integration.api.command.ingest;
 
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.integration.api.command.IntegrationCommandType;
@@ -28,19 +28,19 @@ import lombok.EqualsAndHashCode;
  */
 @Builder
 @EqualsAndHashCode(callSuper = true)
-public class FetchReply extends IntegrationReply<FetchReplyPayload> {
+public class IngestReply extends IntegrationReply<IngestReplyPayload> {
 
-    public FetchReply() {
+    public IngestReply() {
         super(IntegrationCommandType.FETCH);
     }
 
-    public FetchReply(String commandId, String errorDetails) {
+    public IngestReply(String commandId, String errorDetails) {
         super(IntegrationCommandType.FETCH, commandId, CommandStatus.ERROR);
         this.errorDetails = errorDetails;
     }
 
-    public FetchReply(String commandId, FetchReplyPayload fetchReplyPayload) {
+    public IngestReply(String commandId, IngestReplyPayload ingestReplyPayload) {
         super(IntegrationCommandType.FETCH, commandId, CommandStatus.SUCCEEDED);
-        this.payload = fetchReplyPayload;
+        this.payload = ingestReplyPayload;
     }
 }

--- a/src/main/java/io/gravitee/integration/api/command/ingest/IngestReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/ingest/IngestReplyPayload.java
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command.list;
 
-import io.gravitee.integration.api.command.IntegrationCommand;
-import io.gravitee.integration.api.command.IntegrationCommandType;
-import lombok.EqualsAndHashCode;
+package io.gravitee.integration.api.command.ingest;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Api;
+import java.util.List;
+import lombok.Builder;
+import lombok.Singular;
 
 /**
- * @author Remi Baptiste (remi.baptiste at graviteesource.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@EqualsAndHashCode(callSuper = true)
-public class ListCommand extends IntegrationCommand<ListCommandPayload> {
-
-    public ListCommand() {
-        super(IntegrationCommandType.LIST);
-        this.payload = new ListCommandPayload();
-    }
-}
+@Builder
+public record IngestReplyPayload(@Singular("api") List<Api> apis) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/subscribe/SubscribeCommandPayload.java
@@ -17,11 +17,10 @@
 package io.gravitee.integration.api.command.subscribe;
 
 import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.Asset;
 import io.gravitee.integration.api.model.Subscription;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record SubscribeCommandPayload(Asset asset, Subscription subscription) implements Payload {}
+public record SubscribeCommandPayload(String apiId, Subscription subscription) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/model/Api.java
+++ b/src/main/java/io/gravitee/integration/api/model/Api.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -31,20 +32,19 @@ import lombok.NoArgsConstructor;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPropertyOrder({ "id", "name", "version", "description", "host", "path", "type", "pages", "plans" })
+@JsonPropertyOrder({ "id", "name", "version", "description", "connectionDetails", "type", "pages", "plans" })
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-public final class Asset implements Serializable {
+public final class Api implements Serializable {
 
     private String id;
     private String name;
     private String version;
     private String description;
-    private String host;
-    private String path;
-    private AssetType type;
+    private Map<String, String> connectionDetails;
+    private ApiType type;
     private List<Page> pages;
     private List<Plan> plans;
 }

--- a/src/main/java/io/gravitee/integration/api/model/ApiType.java
+++ b/src/main/java/io/gravitee/integration/api/model/ApiType.java
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-package io.gravitee.integration.api.command.fetch;
-
-import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.Asset;
-import java.util.List;
-import lombok.Builder;
-import lombok.Singular;
+package io.gravitee.integration.api.model;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
-public record FetchCommandPayload(@Singular List<Asset> assets) implements Payload {}
+public enum ApiType {
+    PROXY,
+    MESSAGE,
+}

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
@@ -17,7 +17,7 @@
 package io.gravitee.integration.api.plugin;
 
 import io.gravitee.common.component.LifecycleComponent;
-import io.gravitee.integration.api.model.Asset;
+import io.gravitee.integration.api.model.Api;
 import io.gravitee.integration.api.model.Subscription;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
@@ -28,9 +28,9 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface IntegrationProvider extends LifecycleComponent<IntegrationProvider> {
-    Flowable<Asset> listAssets();
+    Flowable<Api> discover();
 
-    Flowable<Asset> fetchAssets(List<Asset> assets);
+    Flowable<Api> ingest(List<Api> apis);
 
-    Single<Subscription> subscribe(Asset asset, Subscription subscription);
+    Single<Subscription> subscribe(String apiId, Subscription subscription);
 }

--- a/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
+++ b/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
@@ -18,11 +18,11 @@ package io.gravitee.integration.api.websocket.command;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
 import io.gravitee.integration.api.command.IntegrationCommandType;
-import io.gravitee.integration.api.command.fetch.FetchCommand;
-import io.gravitee.integration.api.command.fetch.FetchReply;
+import io.gravitee.integration.api.command.discover.DiscoverCommand;
+import io.gravitee.integration.api.command.discover.DiscoverReply;
 import io.gravitee.integration.api.command.hello.HelloCommand;
-import io.gravitee.integration.api.command.list.ListCommand;
-import io.gravitee.integration.api.command.list.ListReply;
+import io.gravitee.integration.api.command.ingest.IngestCommand;
+import io.gravitee.integration.api.command.ingest.IngestReply;
 import io.gravitee.integration.api.command.subscribe.SubscribeCommand;
 import io.gravitee.integration.api.command.subscribe.SubscribeReply;
 import java.util.Map;
@@ -40,17 +40,17 @@ public class IntegrationExchangeSerDe extends DefaultExchangeSerDe {
                 IntegrationCommandType.HELLO.name(),
                 HelloCommand.class,
                 IntegrationCommandType.FETCH.name(),
-                FetchCommand.class,
+                IngestCommand.class,
                 IntegrationCommandType.LIST.name(),
-                ListCommand.class,
+                DiscoverCommand.class,
                 IntegrationCommandType.SUBSCRIBE.name(),
                 SubscribeCommand.class
             ),
             Map.of(
                 IntegrationCommandType.FETCH.name(),
-                FetchReply.class,
+                IngestReply.class,
                 IntegrationCommandType.LIST.name(),
-                ListReply.class,
+                DiscoverReply.class,
                 IntegrationCommandType.SUBSCRIBE.name(),
                 SubscribeReply.class
             )


### PR DESCRIPTION
**Description**

Rename:
- `Asset` into `Api` to use the Gravitee naming
- `AssetType` becomes `ApiType` and the enum match to Gravitee naming (`Proxy` and `Message`)
- `List` becomes `Discover`
- `Fetch` becomes `Ingest`

In `Api`, `host` and `path` have been transformed into an attribute `connectionDetails` that is a `Map<String,String>` that will contain all information necessary to call the API.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-rename-asset-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-rename-asset-SNAPSHOT/gravitee-integration-api-1.0.0-rename-asset-SNAPSHOT.zip)
  <!-- Version placeholder end -->
