### PR TITLE
feat: add hashedConfiguration to HelloCommandPayload

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/hello/HelloCommandPayload.java
@@ -33,4 +33,5 @@ import lombok.experimental.SuperBuilder;
 public class HelloCommandPayload extends io.gravitee.exchange.api.command.hello.HelloCommandPayload {
 
     private String provider;
+    private String hashedConfiguration;
 }

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
@@ -19,6 +19,7 @@ package io.gravitee.integration.api.plugin;
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.integration.api.model.Api;
 import io.gravitee.integration.api.model.Subscription;
+import io.gravitee.integration.api.plugin.configuration.IntegrationProviderConfiguration;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -28,6 +29,8 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface IntegrationProvider extends LifecycleComponent<IntegrationProvider> {
+    IntegrationProviderConfiguration getConfiguration();
+
     Flowable<Api> discover();
 
     Flowable<Api> ingest(List<Api> apis);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4510

**Description**

Add an attribute to send hashed configuration in the HelloCommand payload

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-hash-config-hello-command-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-hash-config-hello-command-SNAPSHOT/gravitee-integration-api-1.0.0-hash-config-hello-command-SNAPSHOT.zip)
  <!-- Version placeholder end -->
