### PR TITLE
Feat add unique id api

### DIFF
--- a/src/main/java/io/gravitee/integration/api/model/Api.java
+++ b/src/main/java/io/gravitee/integration/api/model/Api.java
@@ -32,13 +32,14 @@ import lombok.NoArgsConstructor;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonPropertyOrder({ "id", "name", "version", "description", "connectionDetails", "type", "pages", "plans" })
+@JsonPropertyOrder({ "uniqueId", "id", "name", "version", "description", "connectionDetails", "type", "pages", "plans" })
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 public final class Api implements Serializable {
 
+    private String uniqueId;
     private String id;
     private String name;
     private String version;


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4192

**Description**

Add a unique id field for Api in order to differentiate APIs with the same id. For instance, with the AWS Api Gateway integration provider, we can have the same API but on different stages which result in different APIs in Gravitee. This unique id allow us to manage this and it is the responsibility of the plugin to generate this.