### PR TITLE
feat: use gravitee-node Configuration interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <gravitee-bom.version>7.0.23</gravitee-bom.version>
         <gravitee-common.version>4.2.0</gravitee-common.version>
+        <gravitee-node.version>5.13.0</gravitee-node.version>
         <gravitee-exchange.version>1.4.2</gravitee-exchange.version>
     </properties>
 
@@ -48,10 +49,23 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>io.gravitee.exchange</groupId>
             <artifactId>gravitee-exchange-api</artifactId>
@@ -73,13 +87,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Spring dependencies -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProviderFactory.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProviderFactory.java
@@ -16,7 +16,7 @@
 
 package io.gravitee.integration.api.plugin;
 
-import org.springframework.core.env.Environment;
+import io.gravitee.node.api.configuration.Configuration;
 
 /**
  * @author Remi Baptiste (remi.baptiste at graviteesource.com)
@@ -26,9 +26,9 @@ public interface IntegrationProviderFactory<I extends IntegrationProvider> {
     /**
      * Create an integration provider using Spring Environment and a Prefix to load the configuration
      * @param id The id of the integration provider.
-     * @param environment The Spring Environment where to load the configuration.
+     * @param environment The Environment where to load the configuration.
      * @param prefix The prefix to use to load the configuration.
      * @return The created integration provider.
      */
-    I createIntegrationProvider(String id, Environment environment, String prefix);
+    I createIntegrationProvider(String id, Configuration environment, String prefix);
 }


### PR DESCRIPTION
**Description**

This prevents us from depending directly on Spring.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-remove-spring-dep-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-remove-spring-dep-SNAPSHOT/gravitee-integration-api-1.0.0-remove-spring-dep-SNAPSHOT.zip)
  <!-- Version placeholder end -->
