### PR TITLE
Apim 4899 solace

### DIFF
--- a/src/main/java/io/gravitee/integration/api/model/PlanSecurityType.java
+++ b/src/main/java/io/gravitee/integration/api/model/PlanSecurityType.java
@@ -22,6 +22,6 @@ package io.gravitee.integration.api.model;
  */
 public enum PlanSecurityType {
     API_KEY,
-    OAUTH,
+    OAUTH2,
     JWT,
 }


### PR DESCRIPTION
**Issue**

[Link to the original issue](https://gravitee.atlassian.net/browse/APIM-4899)

**Description**

To comply with others parts of APIM rename OAUTH to OAUTH2.

**Additional context**

Nothing it's only a part needed for Solace integration in federation part
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim-4899-solace-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-apim-4899-solace-SNAPSHOT/gravitee-integration-api-1.0.0-apim-4899-solace-SNAPSHOT.zip)
  <!-- Version placeholder end -->
