### PR TITLE
fix: return a result instead of updated subscription when subscribing

### DIFF
--- a/src/main/java/io/gravitee/integration/api/model/Subscription.java
+++ b/src/main/java/io/gravitee/integration/api/model/Subscription.java
@@ -28,8 +28,7 @@ public record Subscription(
     String graviteeSubscriptionId,
     String graviteeApplicationName,
     SubscriptionType type,
-    Map<String, String> metadata,
-    String apiKey
+    Map<String, String> metadata
 ) {
     public static final String METADATA_PLAN_ID = "planId";
 }

--- a/src/main/java/io/gravitee/integration/api/model/SubscriptionResult.java
+++ b/src/main/java/io/gravitee/integration/api/model/SubscriptionResult.java
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package io.gravitee.integration.api.command.subscribe;
+package io.gravitee.integration.api.model;
 
-import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.SubscriptionResult;
+import java.util.Map;
+import lombok.Builder;
 
-/**
- * @author Remi Baptiste (remi.baptiste at graviteesource.com)
- * @author GraviteeSource Team
- */
-public record SubscribeReplyPayload(SubscriptionResult subscription) implements Payload {}
+@Builder
+public record SubscriptionResult(String graviteeSubscriptionId, Map<String, String> metadata, String apiKey) {}

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
@@ -19,6 +19,7 @@ package io.gravitee.integration.api.plugin;
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.integration.api.model.Api;
 import io.gravitee.integration.api.model.Subscription;
+import io.gravitee.integration.api.model.SubscriptionResult;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -32,5 +33,5 @@ public interface IntegrationProvider extends LifecycleComponent<IntegrationProvi
 
     Flowable<Api> ingest(List<Api> apis);
 
-    Single<Subscription> subscribe(String apiId, Subscription subscription);
+    Single<SubscriptionResult> subscribe(String apiId, Subscription subscription);
 }


### PR DESCRIPTION
**Description**

fix: return a result instead of updated subscription when subscribing

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim4819-refactor-subscribe-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-apim4819-refactor-subscribe-SNAPSHOT/gravitee-integration-api-1.0.0-apim4819-refactor-subscribe-SNAPSHOT.zip)
  <!-- Version placeholder end -->
