### PR TITLE
feat: add unsubscribe method

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeCommand.java
+++ b/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeCommand.java
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum IntegrationCommandType {
-    FETCH,
-    HELLO,
-    LIST,
-    STOP,
-    SUBSCRIBE,
-    UNSUBSCRIBE,
+package io.gravitee.integration.api.command.unsubscribe;
+
+import io.gravitee.integration.api.command.IntegrationCommand;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class UnsubscribeCommand extends IntegrationCommand<UnsubscribeCommandPayload> {
+
+    public UnsubscribeCommand() {
+        super(IntegrationCommandType.UNSUBSCRIBE);
+    }
+
+    public UnsubscribeCommand(final UnsubscribeCommandPayload unsubscribeCommandPayload) {
+        this();
+        this.payload = unsubscribeCommandPayload;
+    }
 }

--- a/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeCommandPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeCommandPayload.java
@@ -13,17 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum IntegrationCommandType {
-    FETCH,
-    HELLO,
-    LIST,
-    STOP,
-    SUBSCRIBE,
-    UNSUBSCRIBE,
-}
+package io.gravitee.integration.api.command.unsubscribe;
+
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.integration.api.model.Subscription;
+import java.util.Map;
+
+public record UnsubscribeCommandPayload(String apiId, Subscription subscription) implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeReply.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.integration.api.command.unsubscribe;
+
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.integration.api.command.IntegrationCommandType;
+import io.gravitee.integration.api.command.IntegrationReply;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class UnsubscribeReply extends IntegrationReply<UnsubscribeReplyPayload> {
+
+    public UnsubscribeReply() {
+        super(IntegrationCommandType.UNSUBSCRIBE);
+    }
+
+    public UnsubscribeReply(String commandId, String errorDetails) {
+        super(IntegrationCommandType.UNSUBSCRIBE, commandId, CommandStatus.ERROR);
+        this.errorDetails = errorDetails;
+    }
+
+    public UnsubscribeReply(String commandId, UnsubscribeReplyPayload payload) {
+        super(IntegrationCommandType.UNSUBSCRIBE, commandId, CommandStatus.SUCCEEDED);
+        this.payload = payload;
+    }
+}

--- a/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/unsubscribe/UnsubscribeReplyPayload.java
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.integration.api.command;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum IntegrationCommandType {
-    FETCH,
-    HELLO,
-    LIST,
-    STOP,
-    SUBSCRIBE,
-    UNSUBSCRIBE,
-}
+package io.gravitee.integration.api.command.unsubscribe;
+
+import io.gravitee.exchange.api.command.Payload;
+
+public record UnsubscribeReplyPayload() implements Payload {}

--- a/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
+++ b/src/main/java/io/gravitee/integration/api/plugin/IntegrationProvider.java
@@ -20,6 +20,7 @@ import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.integration.api.model.Api;
 import io.gravitee.integration.api.model.Subscription;
 import io.gravitee.integration.api.model.SubscriptionResult;
+import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -34,4 +35,6 @@ public interface IntegrationProvider extends LifecycleComponent<IntegrationProvi
     Flowable<Api> ingest(List<Api> apis);
 
     Single<SubscriptionResult> subscribe(String apiId, Subscription subscription);
+
+    Completable unsubscribe(String apiId, Subscription subscription);
 }

--- a/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
+++ b/src/main/java/io/gravitee/integration/api/websocket/command/IntegrationExchangeSerDe.java
@@ -25,6 +25,8 @@ import io.gravitee.integration.api.command.ingest.IngestCommand;
 import io.gravitee.integration.api.command.ingest.IngestReply;
 import io.gravitee.integration.api.command.subscribe.SubscribeCommand;
 import io.gravitee.integration.api.command.subscribe.SubscribeReply;
+import io.gravitee.integration.api.command.unsubscribe.UnsubscribeCommand;
+import io.gravitee.integration.api.command.unsubscribe.UnsubscribeReply;
 import java.util.Map;
 
 /**
@@ -44,7 +46,9 @@ public class IntegrationExchangeSerDe extends DefaultExchangeSerDe {
                 IntegrationCommandType.LIST.name(),
                 DiscoverCommand.class,
                 IntegrationCommandType.SUBSCRIBE.name(),
-                SubscribeCommand.class
+                SubscribeCommand.class,
+                IntegrationCommandType.UNSUBSCRIBE.name(),
+                UnsubscribeCommand.class
             ),
             Map.of(
                 IntegrationCommandType.FETCH.name(),
@@ -52,7 +56,9 @@ public class IntegrationExchangeSerDe extends DefaultExchangeSerDe {
                 IntegrationCommandType.LIST.name(),
                 DiscoverReply.class,
                 IntegrationCommandType.SUBSCRIBE.name(),
-                SubscribeReply.class
+                SubscribeReply.class,
+                IntegrationCommandType.UNSUBSCRIBE.name(),
+                UnsubscribeReply.class
             )
         );
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4819

**Description**

Define a new command to handle the unsubscribe to clean the provider data of any data related to a closed subscription.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-apim4819-unsubscribe-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-apim4819-unsubscribe-SNAPSHOT/gravitee-integration-api-1.0.0-apim4819-unsubscribe-SNAPSHOT.zip)
  <!-- Version placeholder end -->
