### PR TITLE
feat: modify discover command reply to return total count of found APIs to ingest

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReplyPayload.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReplyPayload.java
@@ -16,11 +16,9 @@
 package io.gravitee.integration.api.command.discover;
 
 import io.gravitee.exchange.api.command.Payload;
-import io.gravitee.integration.api.model.Api;
-import java.util.List;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record DiscoverReplyPayload(List<Api> apis) implements Payload {}
+public record DiscoverReplyPayload(long totalCount) implements Payload {}


### PR DESCRIPTION
**Issue**

[Link to the original issue](https://gravitee.atlassian.net/browse/APIM-4370)

**Description**

Modification to integration API discover command. Now it returns totalCount instead of the list of APIs. This is the first step towards previewing APIs before ingestions. This task focuses only on the number of APIs. The next one will be about returning a paginated list of APIs.