### PR TITLE
feat: to distinct validation type by provider let provider plugin sel…

### DIFF
--- a/src/main/java/io/gravitee/integration/api/model/Plan.java
+++ b/src/main/java/io/gravitee/integration/api/model/Plan.java
@@ -23,4 +23,9 @@ import lombok.Builder;
  * @author GraviteeSource Team
  */
 @Builder
-public record Plan(String id, String name, String description, PlanSecurityType planSecurityType) {}
+public record Plan(String id, String name, String description, PlanSecurityType planSecurityType, Validation validation) {
+    public enum Validation {
+        AUTO,
+        MANUAL,
+    }
+}


### PR DESCRIPTION
Add new parameter to allow plugin to choose type of validation should be used for plan
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-allow-plugin-choose-validation-method-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-allow-plugin-choose-validation-method-SNAPSHOT/gravitee-integration-api-1.0.0-allow-plugin-choose-validation-method-SNAPSHOT.zip)
  <!-- Version placeholder end -->
