### PR TITLE
Revert "feat: to distinct validation type by provider let provider plugin sel…"

### DIFF
--- a/src/main/java/io/gravitee/integration/api/model/Plan.java
+++ b/src/main/java/io/gravitee/integration/api/model/Plan.java
@@ -23,9 +23,4 @@ import lombok.Builder;
  * @author GraviteeSource Team
  */
 @Builder
-public record Plan(String id, String name, String description, PlanSecurityType planSecurityType, Validation validation) {
-    public enum Validation {
-        AUTO,
-        MANUAL,
-    }
-}
+public record Plan(String id, String name, String description, PlanSecurityType planSecurityType) {}


### PR DESCRIPTION
Reverts gravitee-io/gravitee-integration-api#18
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-revert-18-allow-plugin-choose-validation-method-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/1.0.0-revert-18-allow-plugin-choose-validation-method-SNAPSHOT/gravitee-integration-api-1.0.0-revert-18-allow-plugin-choose-validation-method-SNAPSHOT.zip)
  <!-- Version placeholder end -->
