### PR TITLE
feat: add support for partial discovery in the ` DiscoverReply ` command

### DIFF
--- a/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReply.java
+++ b/src/main/java/io/gravitee/integration/api/command/discover/DiscoverReply.java
@@ -16,7 +16,6 @@
 package io.gravitee.integration.api.command.discover;
 
 import io.gravitee.exchange.api.command.CommandStatus;
-import io.gravitee.exchange.api.command.Payload;
 import io.gravitee.integration.api.command.IntegrationCommandType;
 import io.gravitee.integration.api.command.IntegrationReply;
 import io.gravitee.integration.api.model.Api;
@@ -46,8 +45,12 @@ public class DiscoverReply extends IntegrationReply<DiscoverReply.Payload> {
     }
 
     public DiscoverReply(String commandId, List<Api> apis) {
-        this(commandId, new Payload(apis));
+        this(commandId, new Payload(apis, false));
     }
 
-    public record Payload(List<Api> apis) implements io.gravitee.exchange.api.command.Payload {}
+    public DiscoverReply(String commandId, List<Api> apis, boolean isPartialDiscovery) {
+        this(commandId, new Payload(apis, isPartialDiscovery));
+    }
+
+    public record Payload(List<Api> apis, boolean isPartialDiscovery) implements io.gravitee.exchange.api.command.Payload {}
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9916

**Description**

This PR extends the **DiscoverReply payload** with a new flag. This flag indicates if the discover command was stopped early to prevent a timeout, signifying that the reply contains only **partially discovered APIs**.


---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-apim-9916-partial-discovery-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/integration/gravitee-integration-api/5.1.0-apim-9916-partial-discovery-SNAPSHOT/gravitee-integration-api-5.1.0-apim-9916-partial-discovery-SNAPSHOT.zip)
  <!-- Version placeholder end -->
